### PR TITLE
Use a font atlas

### DIFF
--- a/font.go
+++ b/font.go
@@ -99,7 +99,6 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 
 	var coords []point
 
-	n := 0
 	// Iterate through all characters in string
 	for i := range indices {
 
@@ -136,16 +135,14 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)
 		x += float32((ch.advance >> 6)) * scale // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
-
-		n += 6
 	}
 
 	gl.BindVertexArray(f.vao)
 	gl.ActiveTexture(gl.TEXTURE0)
 	gl.BindTexture(gl.TEXTURE_2D, f.textureID)
 	gl.BindBuffer(gl.ARRAY_BUFFER, f.vbo)
-	gl.BufferData(gl.ARRAY_BUFFER, len(coords)*4*n, gl.Ptr(coords), gl.DYNAMIC_DRAW)
-	gl.DrawArrays(gl.TRIANGLES, 0, int32(n))
+	gl.BufferData(gl.ARRAY_BUFFER, len(coords)*16, gl.Ptr(coords), gl.DYNAMIC_DRAW)
+	gl.DrawArrays(gl.TRIANGLES, 0, int32(len(coords)))
 
 	gl.BindVertexArray(0)
 	gl.BindTexture(gl.TEXTURE_2D, 0)

--- a/font.go
+++ b/font.go
@@ -101,7 +101,6 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 
 	// Iterate through all characters in string
 	for i := range indices {
-
 		//get rune
 		runeIndex := indices[i]
 
@@ -126,12 +125,12 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		var y1 = ypos
 		var y2 = ypos + h
 
-		coords = append(coords, point{x1, y1, float32(ch.x), 0})
-		coords = append(coords, point{x2, y1, float32(ch.x) + float32(ch.width)/float32(f.atlasWidth), 0})
-		coords = append(coords, point{x1, y2, float32(ch.x), float32(ch.height) / float32(f.atlasHeight)})
-		coords = append(coords, point{x2, y1, float32(ch.x) + float32(ch.width)/float32(f.atlasWidth), 0})
-		coords = append(coords, point{x1, y2, float32(ch.x), float32(ch.height) / float32(f.atlasHeight)})
-		coords = append(coords, point{x2, y2, float32(ch.x) + float32(ch.width)/float32(f.atlasWidth), float32(ch.height) / float32(f.atlasHeight)})
+		coords = append(coords, point{x1, y1, float32(ch.x) / float32(f.atlasWidth), 0})
+		coords = append(coords, point{x2, y1, float32(ch.x)/float32(f.atlasWidth) + float32(ch.width)/float32(f.atlasWidth), 0})
+		coords = append(coords, point{x1, y2, float32(ch.x) / float32(f.atlasWidth), float32(ch.height) / float32(f.atlasHeight)})
+		coords = append(coords, point{x2, y1, float32(ch.x)/float32(f.atlasWidth) + float32(ch.width)/float32(f.atlasWidth), 0})
+		coords = append(coords, point{x1, y2, float32(ch.x) / float32(f.atlasWidth), float32(ch.height) / float32(f.atlasHeight)})
+		coords = append(coords, point{x2, y2, float32(ch.x)/float32(f.atlasWidth) + float32(ch.width)/float32(f.atlasWidth), float32(ch.height) / float32(f.atlasHeight)})
 
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)
 		x += float32((ch.advance >> 6)) * scale // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))

--- a/font.go
+++ b/font.go
@@ -144,7 +144,7 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 	gl.ActiveTexture(gl.TEXTURE0)
 	gl.BindTexture(gl.TEXTURE_2D, f.textureID)
 	gl.BindBuffer(gl.ARRAY_BUFFER, f.vbo)
-	gl.BufferData(gl.ARRAY_BUFFER, len(coords)*4, gl.Ptr(coords), gl.DYNAMIC_DRAW)
+	gl.BufferData(gl.ARRAY_BUFFER, len(coords)*4*n, gl.Ptr(coords), gl.DYNAMIC_DRAW)
 	gl.DrawArrays(gl.TRIANGLES, 0, int32(n))
 
 	gl.BindVertexArray(0)

--- a/font.go
+++ b/font.go
@@ -25,8 +25,8 @@ type Font struct {
 	program     uint32
 	textureID   uint32 // Holds the glyph texture id.
 	color       color
-	atlasWidth  int32
-	atlasHeight int32
+	atlasWidth  float32
+	atlasHeight float32
 }
 
 type color struct {
@@ -125,12 +125,12 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		var y1 = ypos
 		var y2 = ypos + h
 
-		coords = append(coords, point{x1, y1, float32(ch.x) / float32(f.atlasWidth), 0})
-		coords = append(coords, point{x2, y1, float32(ch.x)/float32(f.atlasWidth) + float32(ch.width)/float32(f.atlasWidth), 0})
-		coords = append(coords, point{x1, y2, float32(ch.x) / float32(f.atlasWidth), float32(ch.height) / float32(f.atlasHeight)})
-		coords = append(coords, point{x2, y1, float32(ch.x)/float32(f.atlasWidth) + float32(ch.width)/float32(f.atlasWidth), 0})
-		coords = append(coords, point{x1, y2, float32(ch.x) / float32(f.atlasWidth), float32(ch.height) / float32(f.atlasHeight)})
-		coords = append(coords, point{x2, y2, float32(ch.x)/float32(f.atlasWidth) + float32(ch.width)/float32(f.atlasWidth), float32(ch.height) / float32(f.atlasHeight)})
+		coords = append(coords, point{x1, y1, float32(ch.x) / f.atlasWidth, 0})
+		coords = append(coords, point{x2, y1, float32(ch.x)/f.atlasWidth + float32(ch.width)/f.atlasWidth, 0})
+		coords = append(coords, point{x1, y2, float32(ch.x) / f.atlasWidth, float32(ch.height) / f.atlasHeight})
+		coords = append(coords, point{x2, y1, float32(ch.x)/f.atlasWidth + float32(ch.width)/f.atlasWidth, 0})
+		coords = append(coords, point{x1, y2, float32(ch.x) / f.atlasWidth, float32(ch.height) / f.atlasHeight})
+		coords = append(coords, point{x2, y2, float32(ch.x)/f.atlasWidth + float32(ch.width)/f.atlasWidth, float32(ch.height) / f.atlasHeight})
 
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)
 		x += float32((ch.advance >> 6)) * scale // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
@@ -142,7 +142,6 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 	gl.BindBuffer(gl.ARRAY_BUFFER, f.vbo)
 	gl.BufferData(gl.ARRAY_BUFFER, len(coords)*16, gl.Ptr(coords), gl.DYNAMIC_DRAW)
 	gl.DrawArrays(gl.TRIANGLES, 0, int32(len(coords)))
-
 	gl.BindVertexArray(0)
 	gl.BindTexture(gl.TEXTURE_2D, 0)
 	gl.UseProgram(0)

--- a/font.go
+++ b/font.go
@@ -97,9 +97,6 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 	//set text color
 	gl.Uniform4f(gl.GetUniformLocation(f.program, gl.Str("textColor\x00")), f.color.r, f.color.g, f.color.b, f.color.a)
 
-	gl.ActiveTexture(gl.TEXTURE0)
-	gl.BindVertexArray(f.vao)
-
 	var coords []point
 
 	n := 0
@@ -125,17 +122,17 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		h := float32(ch.height) * scale
 
 		//set quad positions
-		//var x1 = xpos
+		var x1 = xpos
 		var x2 = xpos + w
-		//var y1 = ypos
+		var y1 = ypos
 		var y2 = ypos + h
 
-		coords = append(coords, point{x2, -y2, float32(ch.x), 0})
-		coords = append(coords, point{x2 + w, -y2, float32(ch.x) + float32(ch.width)/float32(f.atlasWidth), 0})
-		coords = append(coords, point{x2, -y2 - h, float32(ch.x), float32(ch.height) / float32(f.atlasHeight)})
-		coords = append(coords, point{x2 + w, -y2, float32(ch.x) + float32(ch.width)/float32(f.atlasWidth), 0})
-		coords = append(coords, point{x2, -y2 - h, float32(ch.x), float32(ch.height) / float32(f.atlasHeight)})
-		coords = append(coords, point{x2 + w, -y2 - h, float32(ch.x) + float32(ch.width)/float32(f.atlasWidth), float32(ch.height) / float32(f.atlasHeight)})
+		coords = append(coords, point{x1, y1, float32(ch.x), 0})
+		coords = append(coords, point{x2, y1, float32(ch.x) + float32(ch.width)/float32(f.atlasWidth), 0})
+		coords = append(coords, point{x1, y2, float32(ch.x), float32(ch.height) / float32(f.atlasHeight)})
+		coords = append(coords, point{x2, y1, float32(ch.x) + float32(ch.width)/float32(f.atlasWidth), 0})
+		coords = append(coords, point{x1, y2, float32(ch.x), float32(ch.height) / float32(f.atlasHeight)})
+		coords = append(coords, point{x2, y2, float32(ch.x) + float32(ch.width)/float32(f.atlasWidth), float32(ch.height) / float32(f.atlasHeight)})
 
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)
 		x += float32((ch.advance >> 6)) * scale // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
@@ -143,16 +140,13 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		n += 6
 	}
 
-	// Render glyph texture over quad
+	gl.BindVertexArray(f.vao)
+	gl.ActiveTexture(gl.TEXTURE0)
 	gl.BindTexture(gl.TEXTURE_2D, f.textureID)
-	// Update content of VBO memory
 	gl.BindBuffer(gl.ARRAY_BUFFER, f.vbo)
-
 	gl.BufferData(gl.ARRAY_BUFFER, len(coords)*4, gl.Ptr(coords), gl.DYNAMIC_DRAW)
 	gl.DrawArrays(gl.TRIANGLES, 0, int32(n))
 
-	//clear opengl textures and programs
-	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 	gl.BindVertexArray(0)
 	gl.BindTexture(gl.TEXTURE_2D, 0)
 	gl.UseProgram(0)

--- a/font.go
+++ b/font.go
@@ -102,7 +102,7 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 
 	var coords []point
 
-	var n int32
+	n := 0
 	// Iterate through all characters in string
 	for i := range indices {
 
@@ -139,6 +139,8 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)
 		x += float32((ch.advance >> 6)) * scale // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
+
+		n += 6
 	}
 
 	// Render glyph texture over quad
@@ -147,7 +149,7 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 	gl.BindBuffer(gl.ARRAY_BUFFER, f.vbo)
 
 	gl.BufferData(gl.ARRAY_BUFFER, len(coords)*4, gl.Ptr(coords), gl.DYNAMIC_DRAW)
-	gl.DrawArrays(gl.TRIANGLES, 0, n)
+	gl.DrawArrays(gl.TRIANGLES, 0, int32(n))
 
 	//clear opengl textures and programs
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)

--- a/truetype.go
+++ b/truetype.go
@@ -23,7 +23,7 @@ type character struct {
 	bearingV int //glyph bearing vertical
 }
 
-func max(a, b int32) int32 {
+func max(a, b float32) float32 {
 	if a > b {
 		return a
 	}
@@ -65,8 +65,8 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, 
 		gh := int32((gBnd.Max.Y - gBnd.Min.Y) >> 6)
 		gw := int32((gBnd.Max.X - gBnd.Min.X) >> 6)
 
-		f.atlasWidth += gw
-		f.atlasHeight = max(f.atlasHeight, gh)
+		f.atlasWidth += float32(gw)
+		f.atlasHeight = max(f.atlasHeight, float32(gh))
 	}
 
 	//create image to draw glyph
@@ -144,17 +144,14 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, 
 	}
 
 	// Generate texture
-	var texture uint32
-	gl.GenTextures(1, &texture)
-	gl.BindTexture(gl.TEXTURE_2D, texture)
+	gl.GenTextures(1, &f.textureID)
+	gl.BindTexture(gl.TEXTURE_2D, f.textureID)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
 	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, int32(rgba.Rect.Dx()), int32(rgba.Rect.Dy()), 0,
 		gl.RGBA, gl.UNSIGNED_BYTE, gl.Ptr(rgba.Pix))
-
-	f.textureID = texture
 
 	gl.BindTexture(gl.TEXTURE_2D, 0)
 

--- a/truetype.go
+++ b/truetype.go
@@ -49,7 +49,7 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, 
 	f.program = program            //set shader program
 	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
 
-	//create new face to measure glyph dimensions
+	//create new face
 	ttfFace := truetype.NewFace(ttf, &truetype.Options{
 		Size:    float64(scale),
 		DPI:     72,
@@ -113,8 +113,7 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, 
 		char.bearingV = gdescent
 		char.bearingH = (int(gBnd.Min.X) >> 6)
 
-		clip := image.Rect(x, 0, int(gw), int(gh))
-		x += int(gw)
+		clip := image.Rect(x, 0, x+int(gw), int(gh))
 
 		//create a freetype context for drawing
 		c := freetype.NewContext()
@@ -127,9 +126,11 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, 
 		c.SetHinting(font.HintingFull)
 
 		//set the glyph dot
-		px := 0 - (int(gBnd.Min.X) >> 6)
+		px := 0 - (int(gBnd.Min.X) >> 6) + x
 		py := (gAscent)
 		pt := freetype.Pt(px, py)
+
+		x += int(gw)
 
 		// Draw the text from mask to image
 		_, err = c.DrawString(string(ch), pt)

--- a/truetype.go
+++ b/truetype.go
@@ -107,6 +107,7 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, 
 		gdescent := int(gBnd.Max.Y) >> 6
 
 		//set w,h and adv, bearing V and bearing H in char
+		char.x = x
 		char.width = int(gw)
 		char.height = int(gh)
 		char.advance = int(gAdv)


### PR DESCRIPTION
Using the technique described there https://en.wikibooks.org/wiki/OpenGL_Programming/Modern_OpenGL_Tutorial_Text_Rendering_02

Code to test:

```
package main

import (
	"fmt"
	"log"
	"runtime"

	"github.com/go-gl/gl/all-core/gl"
	"github.com/go-gl/glfw/v3.2/glfw"
	"github.com/kivutar/glfont"
)

func init() {
	// GLFW event handling must run on the main OS thread
	runtime.LockOSThread()
}

func main() {
	if err := glfw.Init(); err != nil {
		log.Fatalln("failed to initialize glfw:", err)
	}
	defer glfw.Terminate()

	glfw.WindowHint(glfw.Resizable, glfw.False)
	glfw.WindowHint(glfw.ContextVersionMajor, 3)
	glfw.WindowHint(glfw.ContextVersionMinor, 2)
	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)

	var m *glfw.Monitor
	win, err := glfw.CreateWindow(800, 600, "win", m, nil)
	if err != nil {
		panic(err)
	}

	win.MakeContextCurrent()

	// Initialize Glow
	if err := gl.Init(); err != nil {
		panic(err)
	}

	font, err := glfont.LoadFont("font.ttf", int32(32), 800, 600, 150)
	if err != nil {
		panic(err)
	}

	prevTime := glfw.GetTime()
	frames := 0

	for {
		currTime := glfw.GetTime()
		frames++

		if currTime-prevTime >= 1.0 {
			win.SetTitle(fmt.Sprintf("%d FPS", frames))

			frames = 0
			prevTime = currTime
		}

		glfw.PollEvents()
		gl.ClearColor(0, 0, 0, 1)
		gl.Clear(gl.COLOR_BUFFER_BIT)
		gl.Viewport(0, 0, 800*2, 600*2)

		//for i := 1; i <= 20; i++ {
		i := 10
		font.Printf(50, 0+float32(i*16), 0.5, "A")
		//}

		glfw.SwapInterval(1)
		win.SwapBuffers()
	}
}
```